### PR TITLE
sm8550-common: Add 10-point multitouch feature

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -128,6 +128,9 @@ PRODUCT_PACKAGES += \
     vendor.qti.hardware.display.allocator-service \
     vendor.qti.hardware.display.composer-service
 
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.touchscreen.multitouch.jazzhand.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.touchscreen.multitouch.jazzhand.xml
+
 # DRM
 PRODUCT_PACKAGES += \
     android.hardware.drm-service.clearkey


### PR DESCRIPTION
Some apps appear as incompatible in the Google Play Store because this was removed for some reason some time ago